### PR TITLE
Added scale height plots and fixed some warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ plotting_upper_mass_limit_in_Msun: 1.e12
 plotting_number_of_galaxies: 10
 plotting_random_seed: 42
 
+# the mass distribution perpendicular to the disk
+# is binned for the exponential fit to calculate the
+# scaleheight; the region used for the fit has a size
+# of 4 stellar half mass radii (from -2 Rhalf to +2 Rhalf);
+# the number of bins for each galaxy varies
+# so that for each galaxy the bin size is smaller or 
+# equal to scaleheight_binsize_kpc
+scaleheight_binsize_kpc: 0.02
+
 # method used to determine the axis for face-on and edge-on projections:
 # string consisting of:
 #  <component type>_<inner mask radius>_<outer mask radius>_<sigma clipping>

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ plotting_random_seed: 42
 # equal to scaleheight_binsize_kpc
 scaleheight_binsize_kpc: 0.02
 
-# minimum mass to attempt fitting the scaleheight
-scaleheight_lower_mass_limit_in_Msun: 1.e7
+# minimum mass to attempt fitting the scaleheight in units
+# of the initial gas mass per particle
+scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
 # method used to determine the axis for face-on and edge-on projections:
 # string consisting of:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ plotting_random_seed: 42
 # equal to scaleheight_binsize_kpc
 scaleheight_binsize_kpc: 0.02
 
+# minimum mass to attempt fitting the scaleheight
+scaleheight_lower_mass_limit_in_Msun: 1.e7
+
 # method used to determine the axis for face-on and edge-on projections:
 # string consisting of:
 #  <component type>_<inner mask radius>_<outer mask radius>_<sigma clipping>

--- a/colibre_config/config.yml
+++ b/colibre_config/config.yml
@@ -15,5 +15,6 @@ plotting_number_of_galaxies: 10
 plotting_random_seed: 42
 
 scaleheight_binsize_kpc: 0.02
+scaleheight_lower_mass_limit_in_Msun: 1.e8
 
 orientation_method: stars_0xR0.5_R0.5_0sigma

--- a/colibre_config/config.yml
+++ b/colibre_config/config.yml
@@ -14,4 +14,6 @@ plotting_upper_mass_limit_in_Msun: 1.e12
 plotting_number_of_galaxies: 10
 plotting_random_seed: 42
 
+scaleheight_binsize_kpc: 0.02
+
 orientation_method: stars_0xR0.5_R0.5_0sigma

--- a/colibre_config/config.yml
+++ b/colibre_config/config.yml
@@ -15,6 +15,6 @@ plotting_number_of_galaxies: 10
 plotting_random_seed: 42
 
 scaleheight_binsize_kpc: 0.02
-scaleheight_lower_mass_limit_in_Msun: 1.e8
+scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
 orientation_method: stars_0xR0.5_R0.5_0sigma

--- a/colibre_config/mnras.mplstyle
+++ b/colibre_config/mnras.mplstyle
@@ -18,7 +18,7 @@ text.usetex: False
 
 # Legend options
 legend.frameon: False
-legend.fontsize: 6
+legend.fontsize: 8
 legend.handlelength: 5.0
 
 # Figure options for publications

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -345,7 +345,7 @@ if __name__ == "__main__":
                     args.output,
                     observational_data_path,
                     config.scaleheight_binsize_kpc,
-                    config.scaleheight_lower_mass_limit_in_Msun,
+                    config.scaleheight_lower_gasmass_limit_in_number_of_particles,
                     config.orientation_method,
                     make_plots,
                     main_log,

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -345,6 +345,7 @@ if __name__ == "__main__":
                     args.output,
                     observational_data_path,
                     config.scaleheight_binsize_kpc,
+                    config.scaleheight_lower_mass_limit_in_Msun,
                     config.orientation_method,
                     make_plots,
                     main_log,

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -204,6 +204,7 @@ if __name__ == "__main__":
 
     from morpholopy.HI_size import plot_HI_size_mass
     from morpholopy.morphology import plot_morphology
+    from morpholopy.morphology import plot_scaleheights
     from morpholopy.KS import plot_KS_relations
 
     from morpholopy.logging import MainLog
@@ -343,6 +344,7 @@ if __name__ == "__main__":
                     snapshot_filename,
                     args.output,
                     observational_data_path,
+                    config.scaleheight_binsize_kpc,
                     config.orientation_method,
                     make_plots,
                     main_log,
@@ -437,6 +439,11 @@ if __name__ == "__main__":
     )
     all_images.update(
         plot_morphology(
+            args.output, observational_data_path, run_names, all_galaxies_list
+        )
+    )
+    all_images.update(
+        plot_scaleheights(
             args.output, observational_data_path, run_names, all_galaxies_list
         )
     )

--- a/morpholopy/config.py
+++ b/morpholopy/config.py
@@ -30,6 +30,7 @@ direct_read = {
     "plotting_upper_mass_limit_in_Msun": (None, np.float32, unyt.Msun),
     "plotting_number_of_galaxies": (None, np.uint32, None),
     "plotting_random_seed": (42, np.uint32, None),
+    "scaleheight_binsize_kpc": (0.02, np.float32, unyt.kpc),
     "orientation_method": ("stars_0xR0.5_R0.5_0sigma", str, None),
 }
 

--- a/morpholopy/config.py
+++ b/morpholopy/config.py
@@ -31,6 +31,7 @@ direct_read = {
     "plotting_number_of_galaxies": (None, np.uint32, None),
     "plotting_random_seed": (42, np.uint32, None),
     "scaleheight_binsize_kpc": (0.02, np.float32, unyt.kpc),
+    "scaleheight_lower_mass_limit_in_Msun": (1.e9, np.float32, unyt.Msun),
     "orientation_method": ("stars_0xR0.5_R0.5_0sigma", str, None),
 }
 

--- a/morpholopy/config.py
+++ b/morpholopy/config.py
@@ -31,7 +31,7 @@ direct_read = {
     "plotting_number_of_galaxies": (None, np.uint32, None),
     "plotting_random_seed": (42, np.uint32, None),
     "scaleheight_binsize_kpc": (0.02, np.float32, unyt.kpc),
-    "scaleheight_lower_mass_limit_in_Msun": (1.e9, np.float32, unyt.Msun),
+    "scaleheight_lower_gasmass_limit_in_number_of_particles": (10., np.float32, None),
     "orientation_method": ("stars_0xR0.5_R0.5_0sigma", str, None),
 }
 

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -412,6 +412,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         output_path,
         observational_data_path,
         scaleheight_binsize_kpc,
+        scaleheight_lower_mass_limit_in_Msun,
         orientation_type,
         make_plots,
         main_log,
@@ -784,7 +785,8 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
 
     # - Scaleheight plots
     galaxy_data[["HI_scaleheight", "H2_scaleheight", "stars_scaleheight"]] = get_scaleheight(
-            galaxy_log, data, Rhalf, edge_on_rmatrix, gas_mask, stars_mask, index, scaleheight_binsize_kpc
+            galaxy_log, data, Rhalf, edge_on_rmatrix, gas_mask, stars_mask, index, scaleheight_binsize_kpc,
+            scaleheight_lower_mass_limit_in_Msun
     )
     
 

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -793,8 +793,9 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
     # if requested, create invidiual plots for this galaxy
     if make_plots:
         # images
-        images = {
-            f"ZZZ - Galaxy {galaxy_index}": plot_galaxy(
+        images = {f"ZZZ - Galaxy {galaxy_index}": {}}
+
+        galaxy_images = plot_galaxy(
                 catalogue,
                 galaxy_index,
                 index,
@@ -803,7 +804,10 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
                 edge_on_rmatrix,
                 output_path,
             )
-        }
+        images[f"ZZZ - Galaxy {galaxy_index}"].update(
+            galaxy_images["Visualisation"]
+        )
+    
         # individual KS plots
         galaxy_data.compute_medians()
         KS_images = plot_KS_relations(

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -793,7 +793,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
     # if requested, create invidiual plots for this galaxy
     if make_plots:
         # images
-        images = {f"ZZZ - Galaxy {galaxy_index}": {}}
+        images = {f"ZZZ - Galaxy {galaxy_index:08d}": {}}
 
         galaxy_images = plot_galaxy(
                 catalogue,
@@ -804,7 +804,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
                 edge_on_rmatrix,
                 output_path,
             )
-        images[f"ZZZ - Galaxy {galaxy_index}"].update(
+        images[f"ZZZ - Galaxy {galaxy_index:08d}"].update(
             galaxy_images["Visualisation"]
         )
     
@@ -819,7 +819,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
             always_plot_scatter=True,
             plot_integrated_quantities=False,
         )
-        images[f"ZZZ - Galaxy {galaxy_index}"].update(
+        images[f"ZZZ - Galaxy {galaxy_index:08d}"].update(
             KS_images["Combined surface densities"]
         )
     else:

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -412,7 +412,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         output_path,
         observational_data_path,
         scaleheight_binsize_kpc,
-        scaleheight_lower_mass_limit_in_Msun,
+        scaleheight_lower_gasmass_limit_in_number_of_particles,
         orientation_type,
         make_plots,
         main_log,
@@ -786,7 +786,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
     # - Scaleheight plots
     galaxy_data[["HI_scaleheight", "H2_scaleheight", "stars_scaleheight"]] = get_scaleheight(
             galaxy_log, data, Rhalf, edge_on_rmatrix, gas_mask, stars_mask, index, scaleheight_binsize_kpc,
-            scaleheight_lower_mass_limit_in_Msun
+            scaleheight_lower_gasmass_limit_in_number_of_particles
     )
     
 

--- a/morpholopy/galaxy_plots.py
+++ b/morpholopy/galaxy_plots.py
@@ -614,7 +614,6 @@ def plot_galaxy(
     mass_map_face.convert_to_units("Msun / pc**2")
     mass_map_edge.convert_to_units("Msun / pc**2")
     mass_map_face_plot_HI = mass_map_face  # save for H2 ratio plot
-    totalmass_HI = totalmass  # save for H2 ratio plot
     mass_map_face_plot = np.log10(mass_map_face.value)
     mass_map_edge_plot = np.log10(mass_map_edge.value)
 
@@ -658,15 +657,6 @@ def plot_galaxy(
     im = ax_H2_edgeon.imshow(
         mass_map_edge_plot, cmap="Greens", extent=visualise_region, vmin=vmin, vmax=vmax
     )
-
-    circle = pl.Circle(
-        (x, y),
-        (0.99 * r_img_kpc.value) / 1000.0,
-        color="black",
-        fill=False,
-        linewidth=2,
-    )
-
 
     for ax in [ax_stars_faceon, ax_stars_edgeon, 
                ax_HI_faceon, ax_HI_edgeon, 

--- a/morpholopy/galaxy_plots.py
+++ b/morpholopy/galaxy_plots.py
@@ -496,6 +496,59 @@ def plot_galaxy(
         #if shared objects are compiled with e.g. fast math
         FLTMIN = 1.e-30
 
+    image_info =  "Image size: (%.1f x %.1f) kpc, "%(2. * r_img_kpc.value, 2. * r_img_kpc.value)
+    image_info += " resolution: (%i x %i) pixel."%(npix, npix) 
+
+
+    galaxy_info = (
+        " Coordinates (x,y,z) = "
+         + f"({catalogue.positions.xcmbp[halo_id].to('Mpc').value:.02f}, "
+         + f"{catalogue.positions.ycmbp[halo_id].to('Mpc').value:.02f}, "
+         + f"{catalogue.positions.zcmbp[halo_id].to('Mpc').value:.02f}) cMpc, "
+    )
+    galaxy_info += (
+        r"M$_{\mathrm{200,crit}}$ = "
+        + sci_notation(catalogue.masses.mass_200crit[halo_id].to("Msun").value)
+        + r" M$_{\odot}$, "
+    )
+    galaxy_info += (
+        r"M$_{\mathrm{*,30kpc}}$ = "
+        + sci_notation(catalogue.masses.mass_star_30kpc[halo_id].to("Msun").value)
+        + r" M$_{\odot}$, "
+    )
+    galaxy_info += (
+        r"M$_{\mathrm{gas,30kpc}}$ = "
+        + sci_notation(catalogue.masses.mass_gas_30kpc[halo_id].to("Msun").value)
+        + r" M$_{\odot}$, "
+    )
+    galaxy_info += (
+        r"M$_{\mathrm{HI,30kpc}}$ = "
+        + sci_notation(
+            catalogue.gas_hydrogen_species_masses.HI_mass_30_kpc[halo_id]
+            .to("Msun")
+            .value
+        )
+        + r" M$_{\odot}$, "
+    )
+    galaxy_info += (
+        r"M$_{\mathrm{H2,30kpc}}$ = "
+        + sci_notation(
+            catalogue.gas_hydrogen_species_masses.H2_mass_30_kpc[halo_id]
+            .to("Msun")
+            .value
+        )
+        + r" M$_{\odot}$, "
+    )
+    sSFR = (
+        catalogue.apertures.sfr_gas_100_kpc[halo_id]
+        / catalogue.apertures.mass_star_100_kpc[halo_id]
+    )
+    if np.isfinite(sSFR):
+        galaxy_info += (
+            r"sSFR$_{\mathrm{100}}$ = "
+            + sci_notation(sSFR.to("Gyr**(-1)").value)
+            + r" Gyr$^{-1}$"
+        )
 
     stars_faceon_filename = "galaxy_%3.3i_map_stars_faceon.png"%(index)
     stars_edgeon_filename = "galaxy_%3.3i_map_stars_edgeon.png"%(index)
@@ -622,23 +675,6 @@ def plot_galaxy(
         ax.tick_params(labelleft=False, labelbottom=False)
         ax.set_xticks([])
         ax.set_yticks([])
-        #ax.add_artist(circle)
-        ax.plot(
-            [x - lbar_kpc / 2.0, x + lbar_kpc / 2.0],
-            [y + ypos_bar, y + ypos_bar],
-            color="white",
-            linewidth=2,
-            linestyle="solid",
-        )
-        ax.text(
-            x,
-            y + ypos_bar,
-            "%i kpc" % (int(lbar_kpc.value)),
-            color="white",
-            verticalalignment="bottom",
-            horizontalalignment="center",
-        )
-
 
     fig_stars_faceon.savefig(f"{output_path}/{stars_faceon_filename}", dpi = 300)
     fig_stars_edgeon.savefig(f"{output_path}/{stars_edgeon_filename}", dpi = 300)
@@ -658,37 +694,57 @@ def plot_galaxy(
         stars_faceon_filename: {
             "title": "Stars (face-on)",
             "caption": (
-                            "Unattenuated gri image in face-on projection."
+                            "Unattenuated gri image in face-on projection. "
+                            + image_info
+                            + galaxy_info
             ),
         },
         stars_edgeon_filename: {
             "title": "Stars (edge-on)",
             "caption": (
-                            "Unattenuated gri image in edge-on projection."
+                            "Unattenuated gri image in edge-on projection. "
+                            + image_info
+                            + galaxy_info
             ),
         },
         HI_faceon_filename: {
             "title": "HI surface density (face-on)",
             "caption": (
-                            "HI surface density in log Msol / pc**2 in face-on projection."
+                            r"HI surface density in units of log$_{\mathrm{10}}$ M$_{\odot} \,\mathrm{pc}^{-2}$,"
+                            f" colormap range: [ {vmin:.01f}, {vmax:.01f} ], "
+                             "in face-on projection."
+                            + image_info
+                            + galaxy_info
             ),
         },
         HI_edgeon_filename: {
             "title": "HI surface density (edge-on)",
             "caption": (
-                            "HI surface density in log Msol / pc**2 in edge-on projection."
+                            r"HI surface density in units of log$_{\mathrm{10}}$ M$_{\odot} \,\mathrm{pc}^{-2}$, "
+                            f" colormap range: [ {vmin:.01f}, {vmax:.01f} ], "
+                             "in edge-on projection."
+                            + image_info
+                            + galaxy_info
             ),
         },
         H2_faceon_filename: {
             "title": "H2 surface density (face-on)",
             "caption": (
-                            "H2 surface density in log Msol / pc**2 in face-on projection."
+                            r"H2 surface density in units of log$_{\mathrm{10}}$ M$_{\odot} \,\mathrm{pc}^{-2}$, "
+                            f" colormap range: [ {vmin:.01f}, {vmax:.01f} ], "
+                             "in face-on projection."
+                            + image_info
+                            + galaxy_info
             ),
         },
         H2_edgeon_filename: {
             "title": "H2 surface density (edge-on)",
             "caption": (
-                            "H2 surface density in log Msol / pc**2 in edge-on projection."
+                            r"H2 surface density in units of log$_{\mathrm{10}}$ M$_{\odot} \,\mathrm{pc}^{-2}$, "
+                            f" colormap range: [ {vmin:.01f}, {vmax:.01f} ], "
+                             "in edge-on projection."
+                            + image_info
+                            + galaxy_info
             ),
         },
     }

--- a/morpholopy/morphology.py
+++ b/morpholopy/morphology.py
@@ -173,8 +173,10 @@ def get_scaleheight(
     stars_mask: NDArray[bool],
     index: int,
     scaleheight_binsize_kpc: float,
-    scaleheight_lower_mass_limit_in_Msun: float,
+    scaleheight_lower_gasmass_limit_in_number_of_particles: float,
 ) -> Tuple[unyt.unyt_quantity, unyt.unyt_quantity, unyt.unyt_quantity]: 
+
+    initial_gas_mass = data.metadata.initial_mass_table.gas.to("Solar_Mass")
 
     # Image size is 4 * half_mass_radius
     # but at maximum 60 kpc (limited by 30 kpc aperture)
@@ -191,7 +193,7 @@ def get_scaleheight(
     )
 
     minimum_mass = sw.objects.cosmo_array(
-        scaleheight_lower_mass_limit_in_Msun,
+        scaleheight_lower_gasmass_limit_in_number_of_particles * initial_gas_mass,
         comoving=False,
         cosmo_factor=data.gas.masses.cosmo_factor,
     )

--- a/morpholopy/morphology.py
+++ b/morpholopy/morphology.py
@@ -596,33 +596,27 @@ def plot_scaleheights(
 
         # only add points if there is data
         if np.sum(mask_HI_a) > 0:
-            print ("Number of data points for HI (active): ", np.sum(mask_HI_a))
             line = plot_data_on_axis(
                 ax_HI_a, Mstar[mask_HI_a], H_HI[mask_HI_a], color=f"C{i}", plot_scatter=(len(name_list) == 1)
             )
         if np.sum(mask_H2_a) > 0:
-            print ("Number of data points for H2 (active): ", np.sum(mask_H2_a))
             line = plot_data_on_axis(
                 ax_H2_a, Mstar[mask_H2_a], H_H2[mask_H2_a], color=f"C{i}", plot_scatter=(len(name_list) == 1)
             )
         if np.sum(mask_star_a) > 0:
-            print ("Number of data points for star (active): ", np.sum(mask_star_a))
             line = plot_data_on_axis(
                 ax_stars_a, Mstar[mask_star_a], H_star[mask_star_a], color=f"C{i}", plot_scatter=(len(name_list) == 1)
             )
 
         if np.sum(mask_HI_p) > 0:
-            print ("Number of data points for HI (passive): ", np.sum(mask_HI_p))
             line = plot_data_on_axis(
                 ax_HI_p, Mstar[mask_HI_p], H_HI[mask_HI_p], color=f"C{i}", plot_scatter=(len(name_list) == 1)
             )
         if np.sum(mask_H2_p) > 0:
-            print ("Number of data points for H2 (passive): ", np.sum(mask_H2_p))
             line = plot_data_on_axis(
                 ax_H2_p, Mstar[mask_H2_p], H_H2[mask_H2_p], color=f"C{i}", plot_scatter=(len(name_list) == 1)
             )
         if np.sum(mask_star_p) > 0:
-            print ("Number of data points for star (passive): ", np.sum(mask_star_p))
             line = plot_data_on_axis(
                 ax_stars_p, Mstar[mask_star_p], H_star[mask_star_p], color=f"C{i}", plot_scatter=(len(name_list) == 1)
             )

--- a/morpholopy/plot.py
+++ b/morpholopy/plot.py
@@ -67,7 +67,7 @@ def plot_data_on_axis(
     log_y: bool = True,
     linestyle: str = "-",
     marker: str = "o",
-    nbin: int = 20,
+    nbin: int = 10,
 ):
     """
     Plot the given x and y values on the given axis.

--- a/morpholopy/plot.py
+++ b/morpholopy/plot.py
@@ -127,7 +127,7 @@ def plot_data_on_axis(
     with unyt.matplotlib_support:
         if plot_scatter:
             # scale the alpha with the number of points
-            ax.plot(x, y, ".", color=color, alpha=1.0 / np.log10(x.shape[0]))
+            ax.plot(x, y, ".", color=color, alpha=np.minimum(1.0 / np.log10(x.shape[0]), 1.0))
 
         line = plot_broken_line_on_axis(
             ax, xbin_centres, median, color=color, linestyle=linestyle, marker=marker


### PR DESCRIPTION
Added the calculation of the disk scale heights for HI, H2 and stars. These are the steps to calculate the scale heights:

Gas:
A 2D mass map of the gas phase is created with the swiftsimio visualisation routine `project_gas`. The galaxy is rotated into an edge-on view  (based on the orientation method selected in `config.yaml`) and the square image has a length of 4 times the 3D stellar half mass radius (`catalogue.apertures.rhalfmass_star_50_kpc`) but limited to a maximum of 60 kpc (because of the 30 kpc aperture that is used for masking). The number of pixel in each image varies so that the pixel size is always <= `scaleheight_binsize_kpc`, a new parameter in `config.yml`. We then take the mass of each pixel (M_1D) and it's vertical (i.e. perpendicular to the disk) coordinate (z_1D) for the scale height fitting.

Stars:
All stellar particles within an aperture of 30kpc are rotated into an edge-on projection. After the projection, stars within a square with size 4 times the 3D stellar half mass radius (`catalogue.apertures.rhalfmass_star_50_kpc`) but no limitation along the projection axis are selected. The star particles are binned based on their coordinate perpendicular to the disk into a 1D histogram with a binsize of maximum `scaleheight_binsize_kpc` (same number of bins as for gas), where the weights are the masses of each particles. This results in the 1D arrays M_1D (mass per bin) and z_1D (bin centers).

The scale height is determined for both gas and stars by a fit to the exponential function 

```
def exponential(x, Sigma0, H, offset):
     Sigma0 * np.exp(-np.abs(x + offset) / H)
```

and we fit for `Sigma0`, `H`, and `offset` simultaneously, but constrain the fitting parameters to:

| Fitting parameter      |  Variable name | Limit min | Limit max     |
| :---        | :---        |    ----:   |          ---: |
| Amplitude | Sigma0      | M_1D.max()/10       | M_1D.max()*10   |
| Scale height | H   | 1.e-5        | 100     |
| Vertical offset | offset   | -5        | 5    |

to improve the fitting. Particularly important is a non-zero lower bound on H because of the 1/H factor and the offset should be a small correction.
