### PR TITLE
Add galaxy coordinates and decrease number of bins in plots

### DIFF
--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -761,7 +761,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
     if make_plots:
         # images
         images = {
-            f"ZZZ - Galaxy {galaxy_index}": plot_galaxy(
+            f"Galaxy {galaxy_index}": plot_galaxy(
                 catalogue,
                 galaxy_index,
                 index,
@@ -782,7 +782,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
             always_plot_scatter=True,
             plot_integrated_quantities=False,
         )
-        images[f"ZZZ - Galaxy {galaxy_index}"].update(
+        images[f"Galaxy {galaxy_index}"].update(
             KS_images["Combined surface densities"]
         )
     else:

--- a/morpholopy/galaxy_plots.py
+++ b/morpholopy/galaxy_plots.py
@@ -549,7 +549,10 @@ def plot_galaxy(
     ax.text(
         0.05,
         1.20,
-        "%i Galaxy" % (index + 1),
+        "%i Galaxy" % (index + 1) +
+        f" [r = ({catalogue.positions.xcmbp[halo_id].to('Mpc').value:.02f}, "
+        + f"{catalogue.positions.ycmbp[halo_id].to('Mpc').value:.02f}, "
+        + f"{catalogue.positions.zcmbp[halo_id].to('Mpc').value:.02f}) cMpc]",
         ha="left",
         va="bottom",
         transform=ax.transAxes,

--- a/morpholopy/plot.py
+++ b/morpholopy/plot.py
@@ -67,7 +67,7 @@ def plot_data_on_axis(
     log_y: bool = True,
     linestyle: str = "-",
     marker: str = "o",
-    nbin: int = 20,
+    nbin: int = 10,
 ):
     """
     Plot the given x and y values on the given axis.


### PR DESCRIPTION
This PR adds galaxy coordinates and decreases the default number of bins (for most plots).

We want galaxy coordinates to be able to compare galaxies from the same halo in two different simulations (with the same ICs)

The new info on galaxy coordinates is in the top left corner of galaxy images.


![surface_overview_halo035](https://user-images.githubusercontent.com/20153933/214648191-60d2ceac-2153-4ddf-88de-ce0b191708d3.png)
