### PR TITLE
Add gallery of face-on and edge-on gri images and make individual KS plots optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ scaleheight_binsize_kpc: 0.02
 # of the initial gas mass per particle
 scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
+# flag for extra plots:
+# set to 1 to plot additional KS plots for the individual galaxies
+plot_individual_KS_plots: 0
+
 # method used to determine the axis for face-on and edge-on projections:
 # string consisting of:
 #  <component type>_<inner mask radius>_<outer mask radius>_<sigma clipping>

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
 # flag for extra plots:
 # set to 1 to plot additional KS plots for the individual galaxies
-plot_individual_KS_plots: 0
+make_individual_KS_plots: 0
 
 # method used to determine the axis for face-on and edge-on projections:
 # string consisting of:

--- a/colibre_config/config.yml
+++ b/colibre_config/config.yml
@@ -18,3 +18,5 @@ scaleheight_binsize_kpc: 0.02
 scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
 orientation_method: stars_0xR0.5_R0.5_0sigma
+
+plot_individual_KS_plots: 0

--- a/colibre_config/config.yml
+++ b/colibre_config/config.yml
@@ -19,4 +19,4 @@ scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
 orientation_method: stars_0xR0.5_R0.5_0sigma
 
-make_individual_KS_plots: 0: 0
+make_individual_KS_plots: 0

--- a/colibre_config/config.yml
+++ b/colibre_config/config.yml
@@ -19,4 +19,4 @@ scaleheight_lower_gasmass_limit_in_number_of_particles: 10
 
 orientation_method: stars_0xR0.5_R0.5_0sigma
 
-plot_individual_KS_plots: 0
+make_individual_KS_plots: 0: 0

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -298,7 +298,7 @@ if __name__ == "__main__":
         )
 
         if not args.lazy:
-            all_gallery_images = {"YYY - Gallery": {}}
+            all_gallery_images = {}
             # compute the galaxy properties
             # start by getting the catalogue and snapshot file name
             halo_catalogue_filename = f"{args.input[0]}/{args.catalogues[0]}"
@@ -407,14 +407,14 @@ if __name__ == "__main__":
                     main_log.debug(f"Adding figures for galaxy {index}")
                     all_images.update(images)
                 if gallery_images is not None:
-                    all_gallery_images["YYY - Gallery"].update(gallery_images)
+                    all_gallery_images.update(gallery_images)
             # properly terminate the parallel pool
             # while not strictly necessary, not doing this sometimes spawns
             # confusing warning messages
             pool.close()
             pool.join()
 
-            all_images["YYY - Gallery"] = all_gallery_images["YYY - Gallery"]
+            all_images["YYY - Gallery"] = all_gallery_images
 
             main_log.debug("Creating metadata output file")
             # save plot data using the given metadata name

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -298,6 +298,7 @@ if __name__ == "__main__":
         )
 
         if not args.lazy:
+            all_gallery_images = {"YYY - Gallery": {}}
             # compute the galaxy properties
             # start by getting the catalogue and snapshot file name
             halo_catalogue_filename = f"{args.input[0]}/{args.catalogues[0]}"
@@ -391,7 +392,7 @@ if __name__ == "__main__":
             # fixed
             galaxy_count = 0
             # process all galaxies using the parallel pool
-            for index, galaxy_data, images in pool.imap_unordered(
+            for index, galaxy_data, images, gallery_images in pool.imap_unordered(
                 process_galaxy, arglist
             ):
                 galaxy_count += 1
@@ -404,11 +405,15 @@ if __name__ == "__main__":
                 if images is not None:
                     main_log.debug(f"Adding figures for galaxy {index}")
                     all_images.update(images)
+                if gallery_images is not None:
+                    all_gallery_images["YYY - Gallery"].update(gallery_images)
             # properly terminate the parallel pool
             # while not strictly necessary, not doing this sometimes spawns
             # confusing warning messages
             pool.close()
             pool.join()
+
+            all_images["YYY - Gallery"] = all_gallery_images["YYY - Gallery"]
 
             main_log.debug("Creating metadata output file")
             # save plot data using the given metadata name

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -347,6 +347,7 @@ if __name__ == "__main__":
                     observational_data_path,
                     config.scaleheight_binsize_kpc,
                     config.scaleheight_lower_gasmass_limit_in_number_of_particles,
+                    config.plot_individual_KS_plots,
                     config.orientation_method,
                     make_plots,
                     main_log,

--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -347,7 +347,7 @@ if __name__ == "__main__":
                     observational_data_path,
                     config.scaleheight_binsize_kpc,
                     config.scaleheight_lower_gasmass_limit_in_number_of_particles,
-                    config.plot_individual_KS_plots,
+                    config.make_individual_KS_plots,
                     config.orientation_method,
                     make_plots,
                     main_log,

--- a/morpholopy/config.py
+++ b/morpholopy/config.py
@@ -32,7 +32,7 @@ direct_read = {
     "plotting_random_seed": (42, np.uint32, None),
     "scaleheight_binsize_kpc": (0.02, np.float32, unyt.kpc),
     "scaleheight_lower_gasmass_limit_in_number_of_particles": (10., np.float32, None),
-    "plot_individual_KS_plots": (0, np.uint32, None),
+    "make_individual_KS_plots": (0, np.uint32, None),
     "orientation_method": ("stars_0xR0.5_R0.5_0sigma", str, None),
 }
 

--- a/morpholopy/config.py
+++ b/morpholopy/config.py
@@ -32,6 +32,7 @@ direct_read = {
     "plotting_random_seed": (42, np.uint32, None),
     "scaleheight_binsize_kpc": (0.02, np.float32, unyt.kpc),
     "scaleheight_lower_gasmass_limit_in_number_of_particles": (10., np.float32, None),
+    "plot_individual_KS_plots": (0, np.uint32, None),
     "orientation_method": ("stars_0xR0.5_R0.5_0sigma", str, None),
 }
 

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -794,7 +794,6 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
     if make_plots:
         # images
         images = {f"ZZZ - Galaxy {galaxy_index:08d}": {}}
-
         galaxy_images = plot_galaxy(
                 catalogue,
                 galaxy_index,
@@ -807,6 +806,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         images[f"ZZZ - Galaxy {galaxy_index:08d}"].update(
             galaxy_images["Visualisation"]
         )
+        gallery_images = galaxy_images["Gallery"]
     
         # individual KS plots
         galaxy_data.compute_medians()
@@ -824,5 +824,6 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         )
     else:
         images = None
+        gallery_images = None
 
-    return index, galaxy_data, images
+    return index, galaxy_data, images, gallery_images

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -413,7 +413,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         observational_data_path,
         scaleheight_binsize_kpc,
         scaleheight_lower_gasmass_limit_in_number_of_particles,
-        plot_individual_KS_plots,
+        make_individual_KS_plots,
         orientation_type,
         make_plots,
         main_log,
@@ -809,7 +809,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         )
         gallery_images = galaxy_images["Gallery"]
     
-        if plot_individual_KS_plots:
+        if make_individual_KS_plots:
             # individual KS plots
             galaxy_data.compute_medians()
             KS_images = plot_KS_relations(

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -398,6 +398,9 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
      - the galaxy data (will be put in AllGalaxyData[index])
      - a dictionary of images that will be appended to the images dictionary,
        or None if there are no individual images for this galaxy (most common case)
+     - a separate dictionary only containing the face-on and edge gri images for the
+       stellar disks gallery or None if there are no individual images for this 
+       galaxy (most common case)
     """
 
     # unpack arguments

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -413,6 +413,7 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         observational_data_path,
         scaleheight_binsize_kpc,
         scaleheight_lower_gasmass_limit_in_number_of_particles,
+        plot_individual_KS_plots,
         orientation_type,
         make_plots,
         main_log,
@@ -808,20 +809,21 @@ def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
         )
         gallery_images = galaxy_images["Gallery"]
     
-        # individual KS plots
-        galaxy_data.compute_medians()
-        KS_images = plot_KS_relations(
-            output_path,
-            observational_data_path,
-            [f"Galaxy {galaxy_index}"],
-            [galaxy_data],
-            prefix=f"galaxy_{index:03d}_",
-            always_plot_scatter=True,
-            plot_integrated_quantities=False,
-        )
-        images[f"ZZZ - Galaxy {galaxy_index:08d}"].update(
-            KS_images["Combined surface densities"]
-        )
+        if plot_individual_KS_plots:
+            # individual KS plots
+            galaxy_data.compute_medians()
+            KS_images = plot_KS_relations(
+                output_path,
+                observational_data_path,
+                [f"Galaxy {galaxy_index}"],
+                [galaxy_data],
+                prefix=f"galaxy_{index:03d}_",
+                always_plot_scatter=True,
+                plot_integrated_quantities=False,
+            )
+            images[f"ZZZ - Galaxy {galaxy_index:08d}"].update(
+                KS_images["Combined surface densities"]
+            )
     else:
         images = None
         gallery_images = None

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -384,7 +384,7 @@ class AllGalaxyData:
             yaml.safe_dump(datadict, handle)
 
 
-def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict]]:
+def process_galaxy(args) -> Tuple[int, NDArray[data_fields], Union[None, Dict], Union[None, Dict]]:
     """
     Main galaxy analysis function.
     Called exactly once for every galaxy in the simulation. Executed by

--- a/morpholopy/galaxy_plots.py
+++ b/morpholopy/galaxy_plots.py
@@ -499,11 +499,14 @@ def plot_galaxy(
     image_info =  "Image size: (%.1f x %.1f) kpc, "%(2. * r_img_kpc.value, 2. * r_img_kpc.value)
     image_info += " resolution: (%i x %i) pixel."%(npix, npix) 
 
-    galaxy_info_title = (
-        f"Galaxy {halo_id:08d} " 
-         + f"[ {catalogue.positions.xcmbp[halo_id].to('Mpc').value:.02f}, "
+    galaxy_coords_text = (
+           f"[ {catalogue.positions.xcmbp[halo_id].to('Mpc').value:.02f}, "
          + f"{catalogue.positions.ycmbp[halo_id].to('Mpc').value:.02f}, "
          + f"{catalogue.positions.zcmbp[halo_id].to('Mpc').value:.02f} ] cMpc"
+    )
+
+    galaxy_info_title = (
+        f"Galaxy {halo_id:08d} " + galaxy_coords_text
     )
 
     galaxy_info_short = (
@@ -516,10 +519,7 @@ def plot_galaxy(
     )
 
     galaxy_info = (
-        " Coordinates (x,y,z) = "
-         + f"({catalogue.positions.xcmbp[halo_id].to('Mpc').value:.02f}, "
-         + f"{catalogue.positions.ycmbp[halo_id].to('Mpc').value:.02f}, "
-         + f"{catalogue.positions.zcmbp[halo_id].to('Mpc').value:.02f}) cMpc, "
+        " Coordinates (x,y,z) = " + galaxy_coords_text + ", "
     )
     galaxy_info += (
         r"M$_{\mathrm{200,crit}}$ = "

--- a/morpholopy/galaxy_plots.py
+++ b/morpholopy/galaxy_plots.py
@@ -499,6 +499,21 @@ def plot_galaxy(
     image_info =  "Image size: (%.1f x %.1f) kpc, "%(2. * r_img_kpc.value, 2. * r_img_kpc.value)
     image_info += " resolution: (%i x %i) pixel."%(npix, npix) 
 
+    galaxy_info_title = (
+        f"Galaxy {halo_id:08d} " 
+         + f"[ {catalogue.positions.xcmbp[halo_id].to('Mpc').value:.02f}, "
+         + f"{catalogue.positions.ycmbp[halo_id].to('Mpc').value:.02f}, "
+         + f"{catalogue.positions.zcmbp[halo_id].to('Mpc').value:.02f} ] cMpc"
+    )
+
+    galaxy_info_short = (
+        r"M$_{\mathrm{200,crit}}$ = "
+        + sci_notation(catalogue.masses.mass_200crit[halo_id].to("Msun").value)
+        + r" M$_{\odot}$, "
+        + r"M$_{\mathrm{*,30kpc}}$ = "
+        + sci_notation(catalogue.masses.mass_star_30kpc[halo_id].to("Msun").value)
+        + r" M$_{\odot}$, "
+    )
 
     galaxy_info = (
         " Coordinates (x,y,z) = "
@@ -679,6 +694,23 @@ def plot_galaxy(
     pl.close(fig_HI_edgeon)
     pl.close(fig_H2_faceon)
     pl.close(fig_H2_edgeon)
+
+    plots["Gallery"] = {
+        stars_faceon_filename: {
+            "title": galaxy_info_title,
+            "caption": (
+                            "Unattenuated gri image in face-on projection. "
+                            + galaxy_info_short
+            ),
+        },
+        stars_edgeon_filename: {
+            "title": galaxy_info_title,
+            "caption": (
+                            "Unattenuated gri image in edge-on projection. "
+                            + galaxy_info_short
+            ),
+        },
+    }
 
     plots["Visualisation"] = {
         stars_faceon_filename: {


### PR DESCRIPTION
This version adds a new section "YYY - Gallery" to the webpage which shows all gri images from the individual galaxy sections with a shorter description and a more descriptive image title. 

The new parameter 

`make_individual_KS_plots: 0`

in `config.yml` is a flag that sets whether the individual KS plot are produced (`make_individual_KS_plots: 1`) or not (`make_individual_KS_plots: 0`)