### PR TITLE
Fix typo in the HI size plot

### DIFF
--- a/morpholopy/HI_size.py
+++ b/morpholopy/HI_size.py
@@ -101,7 +101,7 @@ def calculate_HI_size(
     image.convert_to_units("Msun/pc**2")
 
     # Compute the HI mass as the integrated surface density of the image
-    HImass = image.sum() * (R / resolution) ** 2
+    HImass = image.sum() * (2.0 * R / resolution) ** 2
 
     if HImass == 0.0:
         galaxy_log.debug("Neutral gas mass is zero, not computing HI size.")


### PR DESCRIPTION
When computing the pixel size, we need to divide the region length by the number of pixels; since the region is from `-R` to `R`, the region size is `2R`.

Test:

**Old pipeline**

![HI_size_mass (2)](https://user-images.githubusercontent.com/20153933/215356966-ce5503cf-04aa-42ba-8e37-4f394cdcd087.png)

**New pipeline before this fix**

![Screenshot from 2023-01-29 22-29-11](https://user-images.githubusercontent.com/20153933/215356982-242ebd0d-677f-424a-ba5c-3d1ed7483327.png)

**New pipeline after this fix**

![HI_size_mass](https://user-images.githubusercontent.com/20153933/215356992-7ce90f7b-f6a3-493a-89e4-ab7608a2c7b6.png)

