### PR TITLE
Update captions in plots showing axis ratios

### DIFF
--- a/morpholopy/morphology.py
+++ b/morpholopy/morphology.py
@@ -1078,19 +1078,19 @@ def plot_morphology(
         ratio_star_filename: {
             "title": "Axis ratios / Stars",
             "caption": (
-                "Axial ratios of galaxies, based on the stars. a, b and c"
+                "Axial ratios of galaxies, based on the stars. a, b, and c"
                 " (a >= b >= c) represent the lengths of the primary axes."
-                " The axis lengths have been computed from the reduced moment"
-                " of inertia tensor using the iterative scheme of Thob et al. (2018)."
+                " The axis lengths have been computed from the reduced (top) and"
+                " normal (bottom) inertia tensors using the iterative scheme of Thob et al. (2018)."
             ),
         },
         ratio_gas_filename: {
             "title": "Axis ratios / HI+H2 gas",
             "caption": (
-                "Axial ratios of galaxies, based on the neutral gas. a, b and c"
+                "Axial ratios of galaxies, based on the neutral gas. a, b, and c"
                 " (a >= b >= c) represent the lengths of the primary axes. The axis"
-                " lengths have been computed from the reduced moment of inertia tensor"
-                " using the iterative scheme of Thob et al. (2018)."
+                " lengths have been computed from the reduced (top) and"
+                " normal (bottom) inertia tensors using the iterative scheme of Thob et al. (2018)."
             ),
         },
     }


### PR DESCRIPTION
The plots showing axis ratios have two rows, one for the normal tensor and the other for the reduced tensor. The captions of these plots were not outdated, and, hence, were not consistent with the plots. See e.g. https://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/YEAR2022/z0.0_M_U89_L50N376_I303_newtables_npivot0p5_Ppivot5e3_Mseed2e4/index.html#6193315892304572457

This PR corrects it by updating the captions.


