### PR TITLE
Working version of the morphology pipeline for SOAP output

### DIFF
--- a/morphology-pipeline
+++ b/morphology-pipeline
@@ -12,6 +12,7 @@ Usage:
     -C/--config      <configuration directory> \
     -i/--input       <input folder that contains the snapshots and catalogues> \
     -s/--snapshots   <input snapshot> \
+    -g/--groups      <input particle membership> \
     -c/--catalogues  <input catalogue> \
     -o/--output      <directory where output images and web pages are stored> \
    [-n/--run-names   <name for the run>] \
@@ -41,6 +42,7 @@ parser = ap.ArgumentParser(
         "    -C/--config      <configuration directory> \ \n"
         "    -i/--input       <input folder that contains the snapshots and catalogues> \ \n"
         "    -s/--snapshots   <input snapshot> \ \n"
+        "    -g/--groups      <input particle membership> \ \n"
         "    -c/--catalogues  <input catalogue> \ \n"
         "    -o/--output      <directory where output images and web pages are stored> \ \n"
         "   [-n/--run-names   <name for the run>] \ \n"
@@ -66,7 +68,16 @@ parser.add_argument(
     "--catalogues",
     type=str,
     required=True,
-    help="Name of the VELOCIraptor HDF5 .properties file(s). Required.",
+    help="Name of the SOAP HDF5 properties file(s). Required.",
+    nargs="*",
+)
+
+parser.add_argument(
+    "-g",
+    "--groups",
+    type=str,
+    required=True,
+    help="Name of the SOAP HDF5 memberships file(s). Required.",
     nargs="*",
 )
 
@@ -302,6 +313,7 @@ if __name__ == "__main__":
             # compute the galaxy properties
             # start by getting the catalogue and snapshot file name
             halo_catalogue_filename = f"{args.input[0]}/{args.catalogues[0]}"
+            halo_membership_filename = f"{args.input[0]}/{args.groups[0]}"
             snapshot_filename = f"{args.input[0]}/{args.snapshots[0]}"
 
             # load the catalogue and create the filtered catalogue that only
@@ -329,8 +341,9 @@ if __name__ == "__main__":
             # these should correspond to the argument needed by
             # process_galaxy():
             #  - the index in the global galaxy list
-            #  - the catalogue index of the galaxy (its VR/SOAP index)
+            #  - the catalogue index of the galaxy (its SOAP index)
             #  - the catalogue file name
+            #  - the halo membership file name
             #  - the snapshot file name
             #  - the output directory name
             #  - the observational data path
@@ -342,6 +355,7 @@ if __name__ == "__main__":
                     index,
                     galaxy_index,
                     halo_catalogue_filename,
+                    halo_membership_filename,
                     snapshot_filename,
                     args.output,
                     observational_data_path,

--- a/morpholopy/KS.py
+++ b/morpholopy/KS.py
@@ -362,12 +362,12 @@ def plot_KS_relations(
        Data for all the simulations that need to be plotted (can be a single galaxy for
        individual galaxy plots).
      - prefix: str
-       Unique prefix that is prepended to images file names. Useful to distinguish
+       Unique prefix that is prepended to image file names. Useful to distinguish
        individual galaxy images.
      - always_plot_scatter: bool
-       Wheter or not to always plot individual median histrogram bins as well as median lines.
+       Whether to always plot individual median histogram bins as well as median lines.
      - plot_integrated_quantities: bool
-       Whether or not to plot integrated KS plots. Set to False for individual galaxy plots,
+       Whether to plot integrated KS plots. Set to False for individual galaxy plots,
        since a galaxy is only a single point on those plots.
 
     Returns an image data dictionary compatible with MorphologyConfig.add_images().
@@ -444,7 +444,6 @@ def plot_KS_relations(
                     ax.plot([], [], marker=marker, color="k", linestyle="None")[0]
                 )
                 sim_labels.append(name)
-
             if dataname is not None:
                 observational_data = load_observations(
                     sorted(glob.glob(f"{observational_data_path}/{dataname}/*.hdf5"))
@@ -578,14 +577,32 @@ def plot_KS_relations(
         ax.add_artist(sim_legend)
 
     neut_filename = f"{prefix}azimuthal_KS_neutral.png"
+    ax_neut.set_xlabel(
+        r"Neutral Surface Density $\Sigma_{\rm HI+H2}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_neut.set_ylabel(
+        r"Star Formation Rate Surface Density $\rm \left[\frac{M_\odot}{yr \cdot kpc^{2}}\right]$"
+    )
     fig_neut.savefig(f"{output_path}/{neut_filename}", dpi=300)
     pl.close(fig_neut)
 
     at_filename = f"{prefix}azimuthal_KS_atomic.png"
+    ax_at.set_xlabel(
+        r"Atomic Surface Density $\Sigma_{\rm HI}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_at.set_ylabel(
+        r"Star Formation Rate Surface Density $\rm \left[\frac{M_\odot}{yr \cdot kpc^{2}}\right]$"
+    )
     fig_at.savefig(f"{output_path}/{at_filename}", dpi=300)
     pl.close(fig_at)
 
     mol_filename = f"{prefix}azimuthal_KS_molecular.png"
+    ax_mol.set_xlabel(
+        r"Molecular Surface Density $\Sigma_{\rm H2}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_mol.set_ylabel(
+        r"Star Formation Rate Surface Density $\rm \left[\frac{M_\odot}{yr \cdot kpc^{2}}\right]$"
+    )
     fig_mol.savefig(f"{output_path}/{mol_filename}", dpi=300)
     pl.close(fig_mol)
 
@@ -706,14 +723,32 @@ def plot_KS_relations(
         ax.add_artist(sim_legend)
 
     neut_filename = f"{prefix}spatial_KS_neutral.png"
+    ax_neut.set_xlabel(
+        r"Neutral Surface Density $\Sigma_{\rm HI+H2}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_neut.set_ylabel(
+        r"Star Formation Rate Surface Density $\rm \left[\frac{M_\odot}{yr \cdot kpc^{2}}\right]$"
+    )
     fig_neut.savefig(f"{output_path}/{neut_filename}", dpi=300)
     pl.close(fig_neut)
 
     at_filename = f"{prefix}spatial_KS_atomic.png"
+    ax_at.set_xlabel(
+        r"Atomic Surface Density $\Sigma_{\rm HI}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_at.set_ylabel(
+        r"Star Formation Rate Surface Density $\rm \left[\frac{M_\odot}{yr \cdot kpc^{2}}\right]$"
+    )
     fig_at.savefig(f"{output_path}/{at_filename}", dpi=300)
     pl.close(fig_at)
 
     mol_filename = f"{prefix}spatial_KS_molecular.png"
+    ax_mol.set_xlabel(
+        r"Molecular Surface Density $\Sigma_{\rm H2}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_mol.set_ylabel(
+        r"Star Formation Rate Surface Density $\rm \left[\frac{M_\odot}{yr \cdot kpc^{2}}\right]$"
+    )
     fig_mol.savefig(f"{output_path}/{mol_filename}", dpi=300)
     pl.close(fig_mol)
 
@@ -821,14 +856,32 @@ def plot_KS_relations(
         ax.add_artist(sim_legend)
 
     neut_filename = f"{prefix}spatial_tgas_neutral.png"
+    ax_neut.set_xlabel(
+        r"Neutral Surface Density $\Sigma_{\rm HI+H2}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_neut.set_ylabel(
+        r"Neutral gas depletion time $\Sigma_{\rm HI+H2} / \Sigma_{\rm SFR}$ [yr]"
+    )
     fig_neut.savefig(f"{output_path}/{neut_filename}", dpi=300)
     pl.close(fig_neut)
 
     at_filename = f"{prefix}spatial_tgas_atomic.png"
+    ax_at.set_xlabel(
+        r"Atomic Surface Density $\Sigma_{\rm HI}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_at.set_ylabel(
+        r"Atomic gas depletion time $\Sigma_{\rm HI} / \Sigma_{\rm SFR}$ [yr]"
+    )
     fig_at.savefig(f"{output_path}/{at_filename}", dpi=300)
     pl.close(fig_at)
 
     mol_filename = f"{prefix}spatial_tgas_molecular.png"
+    ax_mol.set_xlabel(
+        r"Molecular Surface Density $\Sigma_{\rm H2}$ $\rm \left[\frac{M_\odot}{pc^{2}}\right]$"
+    )
+    ax_mol.set_ylabel(
+        r"Molecular gas depletion time $\Sigma_{\rm H2} / \Sigma_{\rm SFR}$ [yr]"
+    )
     fig_mol.savefig(f"{output_path}/{mol_filename}", dpi=300)
     pl.close(fig_mol)
 

--- a/morpholopy/filtered_catalogue.py
+++ b/morpholopy/filtered_catalogue.py
@@ -12,10 +12,9 @@ a mask determining which galaxies are plotted on an individual basis.
 
 import numpy as np
 import unyt
-from functools import reduce
 
 from numpy.typing import NDArray
-from velociraptor.catalogue.catalogue import VelociraptorCatalogue
+from velociraptor.catalogue.catalogue import Catalogue
 
 
 class FilteredCatalogue:
@@ -30,7 +29,7 @@ class FilteredCatalogue:
 
     def __init__(
         self,
-        catalogue: VelociraptorCatalogue,
+        catalogue: Catalogue,
         minimum_mass_stars: unyt.unyt_quantity,
         mass_variable_stars: str,
         minimum_mass_gas: unyt.unyt_quantity,
@@ -74,13 +73,13 @@ class FilteredCatalogue:
         """
 
         # get the masses from the catalogue
-        Mstar = reduce(getattr, mass_variable_stars.split("."), catalogue)
-        Mgas = reduce(getattr, mass_variable_gas.split("."), catalogue)
+        Mstar = catalogue.get_quantity(mass_variable_stars)
+        Mgas = catalogue.get_quantity(mass_variable_gas)
 
         # compute the mask
         mask = (
             (Mstar >= minimum_mass_stars)
-            & (catalogue.structure_type.structuretype == 10)
+            & (catalogue.get_quantity("structure_type.structuretype") == 10)
             & (Mgas > minimum_mass_gas)
         )
         # turn the mask into a list of indices

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -437,15 +437,6 @@ def process_galaxy(
     catalogue = load_catalogue(catalogue_filename, disregard_units=True)
     membership_data = h5.File(halo_membership_filename, "r")
 
-    # get the particles belonging to this galaxy
-    # particles, _ = groups.extract_halo(halo_index=galaxy_index)
-    # turn this information into a swiftsimio mask and read the data
-    # using swiftsimio
-
-    ##data, mask = to_swiftsimio_dataset(
-    ##    particles, snapshot_filename, generate_extra_mask=True
-    ##)
-
     swift_mask = swiftsimio.mask(snapshot_filename, spatial_only=True)
     # SWIFT data is stored in comoving units, so we need to un-correct
     # the velociraptor data if it is stored in physical.

--- a/morpholopy/galaxy_data.py
+++ b/morpholopy/galaxy_data.py
@@ -481,9 +481,6 @@ def process_galaxy(
     mask = MaskTuple(**particle_name_masks)
     membership_data.close()
 
-    for key, val in particle_name_masks.items():
-        print(key, np.sum(val))
-
     # mask out all particles that are actually bound to the galaxy
     # while at it: convert everything to physical coordinates
     for parttype in ["gas", "dark_matter", "stars", "black_holes"]:
@@ -648,7 +645,6 @@ def process_galaxy(
 
     # - axis ratios and angular momenta
     (a, b, c), z_axis = get_axis_lengths_reduced_tensor(galaxy_log, data.stars, Rhalf)
-    print(a, b, c, z_axis)
     if (a > 0.0) and (b > 0.0) and (c > 0.0):
         galaxy_data["stars_axis_ca_reduced"] = c / a
         galaxy_data["stars_axis_cb_reduced"] = c / b

--- a/morpholopy/morphology.py
+++ b/morpholopy/morphology.py
@@ -357,8 +357,6 @@ def get_axis_lengths_tensor(
     Itensor = (
         (weight[:, None, None] / weight.sum()) * np.ones((weight.shape[0], 3, 3))
     ).value
-    # Note: unyt currently ignores the position units in the *=
-    # i.e. Itensor is dimensionless throughout (even though it should not be)
     for i in range(3):
         for j in range(3):
             Itensor[:, i, j] *= position[:, i] * position[:, j]
@@ -545,20 +543,10 @@ def get_kappa_corot(
     if K == 0.0:
         return 0.0, 0.0
 
-    # np.cross may not preserve units, so we need to multiply them back in
-    try:
-        angular_momentum = mass[:, None] * np.cross(position, velocity)
-        j = angular_momentum.sum(axis=0) / mass.sum()
-        j.convert_to_units("kpc*km/s")
-    except unyt.exceptions.UnitConversionError:
-        angular_momentum = (
-            mass[:, None]
-            * np.cross(position, velocity)
-            * position.units
-            * velocity.units
-        )
-        j = angular_momentum.sum(axis=0) / mass.sum()
-        j.convert_to_units("kpc*km/s")
+    angular_momentum = mass[:, None] * np.cross(position, velocity)
+    j = angular_momentum.sum(axis=0) / mass.sum()
+    j.convert_to_units("kpc*km/s")
+
     j = np.sqrt((j ** 2).sum())
 
     Lz = (angular_momentum * orientation_vector[None, :]).sum(axis=1)

--- a/morpholopy/orientation.py
+++ b/morpholopy/orientation.py
@@ -11,7 +11,7 @@ based on a strategy encoded in a string with the following format:
 where:
  - component type can be stars, gas, ISM, HI, baryons
  - inner mask radius can be 0xR0.5, 0.5R0.5
- - outer mask radius can be R0.5, 2xR0.5, 4xR0.5, 50kpc, R200crit, 0.1Rvir
+ - outer mask radius can be R0.5, 2xR0.5, 4xR0.5, 50kpc, R200crit, 0.1R200crit
  - sigma clipping can be 0sigma (no clipping), 1sigma, 2sigma
 
 This file contains a number of functions that can be called in other
@@ -36,7 +36,6 @@ def get_orientation_mask(
     radius: unyt.unyt_array,
     half_mass_radius: unyt.unyt_quantity,
     R200crit: unyt.unyt_quantity,
-    Rvir: unyt.unyt_quantity,
     inner_aperture: str,
     outer_aperture: str,
 ) -> NDArray[bool]:
@@ -67,8 +66,8 @@ def get_orientation_mask(
         )
     elif outer_aperture == "R200crit":
         mask &= radius < R200crit
-    elif outer_aperture == "0.1Rvir":
-        mask &= radius < 0.1 * Rvir
+    elif outer_aperture == "0.1R200crit":
+        mask &= radius < 0.1 * R200crit
     else:
         raise RuntimeError(f"Unknown outer aperture: {outer_aperture}!")
 
@@ -145,7 +144,6 @@ def get_mass_position_velocity(
     data: SWIFTDataset,
     half_mass_radius: unyt.unyt_quantity,
     R200crit: unyt.unyt_quantity,
-    Rvir: unyt.unyt_quantity,
     orientation_type: str,
 ) -> Tuple[unyt.unyt_array, unyt.unyt_array, unyt.unyt_array]:
     """
@@ -161,7 +159,7 @@ def get_mass_position_velocity(
 
     radius = np.sqrt((position ** 2).sum(axis=1))
     mask = get_orientation_mask(
-        radius, half_mass_radius, R200crit, Rvir, inner_aperture, outer_aperture
+        radius, half_mass_radius, R200crit, inner_aperture, outer_aperture
     )
 
     position = position[mask]
@@ -196,7 +194,6 @@ def get_orientation_matrices(
     data: SWIFTDataset,
     half_mass_radius: unyt.unyt_quantity,
     R200crit: unyt.unyt_quantity,
-    Rvir: unyt.unyt_quantity,
     orientation_type: str,
 ) -> Tuple[NDArray[float], NDArray[float], NDArray[float]]:
     """
@@ -210,7 +207,7 @@ def get_orientation_matrices(
     """
 
     mass, position, velocity = get_mass_position_velocity(
-        data, half_mass_radius, R200crit, Rvir, orientation_type
+        data, half_mass_radius, R200crit, orientation_type
     )
 
     angular_momentum = (mass[:, None] * np.cross(position, velocity)).sum(axis=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ swiftsimio>=6.0.0
 scipy>=1.9.3
 matplotlib>=3.6.2
 swiftpipeline>=0.3.5
+h5py>=3.9.0
+unyt>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-velociraptor>=0.15.8
+velociraptor>=0.16.0
 swiftsimio>=6.0.0
 scipy>=1.9.3
 matplotlib>=3.6.2


### PR DESCRIPTION
**Running morphology pipeline before this update, using VR catalogues:** https://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/YEAR2023/z0.0_M_L12N188_new_pipeline/

**Running morphology pipeline after this update, using only SOAP output:** https://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/YEAR2023/z0.0_M_L12N188_new_pipeline_soap/

**TODO**
- [ ]  For a given halo, load only _a fraction_ of the particle data from the snapshot, containing only those particles that are close to the halo (currently all snapshot data is loaded)